### PR TITLE
Fixed the effective date on moves created by Run Checks wizard #6817

### DIFF
--- a/check.py
+++ b/check.py
@@ -241,6 +241,7 @@ class RunCheck(Wizard):
     def get_move(self, lines, party, account):
         Move = Pool().get('account.move')
         Line = Pool().get('account.move.line')
+        Date = Pool().get('ir.date')
 
         total_debit = sum(line.debit for line in lines)
         total_credit = sum(line.credit for line in lines)
@@ -248,6 +249,7 @@ class RunCheck(Wizard):
 
         return Move(
             journal=self.start.journal,
+            date=Date.today(),
             lines=[
                 # Credit the journal
                 Line(


### PR DESCRIPTION
Strangely all moves from a check run resulted in the date of the move
being the first day of month
The culpit: https://github.com/tryton/account/blob/develop/move.py#L175

The date was actually the first day of current period, set as default
for effective date on move